### PR TITLE
ci: Fix packing step in ci pipeline

### DIFF
--- a/.github/workflows/github-action-build-wrapper.yml
+++ b/.github/workflows/github-action-build-wrapper.yml
@@ -81,7 +81,7 @@ jobs:
             -p:AssemblyVersion=${{ needs.determine-version.outputs.assembly-sem-ver }} `
             -p:AssemblyInformationalVersion=${{ needs.determine-version.outputs.assembly-informational-version }} `
             -p:PackageId=${{ matrix.build.package-id }} `
-            --disable-build-servers `
+            --no-build `
             --configuration Release `
             --output ./bin `
             --warnaserror `


### PR DESCRIPTION
The dotnet pack step was re-building the project but not listening to the UseOpenMP flag, meaning the "*.openmp package" was not actually using OpenMP support. Since everything is built beforehand, it should be safe and more efficient to use the --no-build flag for the packing step. The --disable-build-servers flag should be redunant after this change and is hence removed.