### PR TITLE
ci: Build managed dll non-natively and without runtime identifier

### DIFF
--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build-native:
-    name: Build native libraries for ${{ matrix.rid }}
+    name: Build Native Library for ${{ matrix.rid }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -46,16 +46,16 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Install SWIG (macOS only)
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v5
+
+      - name: Install Build Requirements (macOS only)
         if: runner.os == 'macOS'
         run: |
           brew install swig
           if [ "${{ inputs.use-openmp }}" == "ON" ]; then
             brew install libomp
           fi
-
-      - name: Install .NET SDK
-        uses: actions/setup-dotnet@v5
 
       - name: Build
         shell: pwsh
@@ -75,15 +75,15 @@ jobs:
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }}
 
-      - name: Upload Runtime Binaries
+      - name: Upload Native Library
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.rid }}-runtime-${{ inputs.package-id }}
+          name: ${{ matrix.rid }}-native-${{ inputs.package-id }}
           path: ./minuit2.net/runtimes/
           if-no-files-found: error
 
   build-managed:
-    name: Build managed .NET library
+    name: Build .NET Assembly
     runs-on: windows-2025
     steps:
       - name: Check Out Repository Code
@@ -114,10 +114,10 @@ jobs:
           path: ./minuit2.net/root-license/
           if-no-files-found: error
 
-      - name: Upload C# Assembly
+      - name: Upload .NET Assembly
         uses: actions/upload-artifact@v7
         with:
-          name: csharp-assembly-${{ inputs.package-id }}
+          name: dotnet-assembly-${{ inputs.package-id }}
           path: ./minuit2.net/bin/Release/net8.0/${{ inputs.package-id }}.dll
           if-no-files-found: error
 
@@ -134,10 +134,10 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v5
 
-      - name: Download C# Assembly
+      - name: Download .NET Assembly
         uses: actions/download-artifact@v8
         with:
-          name: csharp-assembly-${{ inputs.package-id }}
+          name: dotnet-assembly-${{ inputs.package-id }}
           path: ./minuit2.net/bin/Release/net8.0/
 
       - name: Download ROOT License
@@ -146,20 +146,20 @@ jobs:
           name: root-license-${{ inputs.package-id }}
           path: ./minuit2.net/root-license/
 
-      - name: Download Runtime Binaries
+      - name: Download Native Libraries
         uses: actions/download-artifact@v8
         with:
-          pattern: "*-runtime-${{ inputs.package-id }}"
+          pattern: "*-native-${{ inputs.package-id }}"
           path: ./minuit2.net/runtimes/
           merge-multiple: true
 
-      - name: Verify Runtime Binaries
+      - name: Verify Native Libraries
         shell: pwsh
         run: |
           $requiredRids = @("win-x86", "win-x64", "win-arm64", "osx-x64", "osx-arm64")
           foreach ($rid in $requiredRids) {
             if (-not (Test-Path "./minuit2.net/runtimes/$rid")) {
-              Write-Error "Cannot package: Missing runtime binaries for RID: $rid"
+              Write-Error "Cannot package: Missing native library for RID: $rid"
               exit 1
             }
           }

--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -99,6 +99,10 @@ jobs:
         shell: pwsh
         run: |
           dotnet build ./minuit2.net/minuit2.net.csproj `
+            -p:Version=${{ inputs.sem-ver }} `
+            -p:FileVersion=${{ inputs.assembly-sem-file-ver }} `
+            -p:AssemblyVersion=${{ inputs.assembly-sem-ver }} `
+            -p:AssemblyInformationalVersion=${{ inputs.assembly-informational-version }} `
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }} `
             --no-self-contained

--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -23,8 +23,8 @@ on:
         type: string
 
 jobs:
-  build-windows:
-    name: Build for ${{ matrix.rid }}
+  build-native:
+    name: Build native libraries for ${{ matrix.rid }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -35,12 +35,24 @@ jobs:
             runner: windows-2025
           - rid: win-arm64
             runner: windows-11-arm
+          - rid: osx-arm64
+            runner: macos-15
+          - rid: osx-x64
+            runner: macos-15-intel
     steps:
       - name: Check Out Repository Code
         uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 1
+
+      - name: Install SWIG (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          brew install swig
+          if [ "${{ inputs.use-openmp }}" == "ON" ]; then
+            brew install libomp
+          fi
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v5
@@ -63,22 +75,6 @@ jobs:
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }}
 
-      - name: Upload C# Assembly
-        if: matrix.rid == 'win-x64'
-        uses: actions/upload-artifact@v7
-        with:
-          name: csharp-assembly-${{ inputs.package-id }}
-          path: ./minuit2.net/bin/Release/net8.0/
-          if-no-files-found: error
-
-      - name: Upload ROOT License
-        if: matrix.rid == 'win-x64'
-        uses: actions/upload-artifact@v7
-        with:
-          name: root-license-${{ inputs.package-id }}
-          path: ./minuit2.net/root-license/
-          if-no-files-found: error
-
       - name: Upload Runtime Binaries
         uses: actions/upload-artifact@v7
         with:
@@ -86,29 +82,15 @@ jobs:
           path: ./minuit2.net/runtimes/
           if-no-files-found: error
 
-  build-macos:
-    name: Build for ${{ matrix.rid }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - rid: osx-arm64
-            runner: macos-15
-          - rid: osx-x64
-            runner: macos-15-intel
+  build-managed:
+    name: Build managed .NET library
+    runs-on: windows-2025
     steps:
       - name: Check Out Repository Code
         uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 1
-
-      - name: Install Dependencies
-        run: |
-          brew install swig
-          if [ "${{ inputs.use-openmp }}" == "ON" ]; then
-            brew install libomp
-          fi
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v5
@@ -117,29 +99,27 @@ jobs:
         shell: pwsh
         run: |
           dotnet build ./minuit2.net/minuit2.net.csproj `
-            --runtime ${{ matrix.rid }} `
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }} `
             --no-self-contained
 
-      - name: Test
-        shell: pwsh
-        run: |
-          dotnet test ./test/minuit2.net.UnitTests/minuit2.net.UnitTests.csproj `
-            --runtime ${{ matrix.rid }} `
-            --configuration Release `
-            -p:UseOpenMP=${{ inputs.use-openmp }}
-
-      - name: Upload Runtime Binaries
+      - name: Upload ROOT License
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.rid }}-runtime-${{ inputs.package-id }}
-          path: ./minuit2.net/runtimes/
+          name: root-license-${{ inputs.package-id }}
+          path: ./minuit2.net/root-license/
+          if-no-files-found: error
+
+      - name: Upload C# Assembly
+        uses: actions/upload-artifact@v7
+        with:
+          name: csharp-assembly-${{ inputs.package-id }}
+          path: ./minuit2.net/bin/Release/net8.0/${{ inputs.package-id }}.dll
           if-no-files-found: error
 
   package:
     name: Create NuGet Package
-    needs: [ build-windows, build-macos ]
+    needs: [ build-native, build-managed ]
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository Code
@@ -175,7 +155,7 @@ jobs:
           $requiredRids = @("win-x86", "win-x64", "win-arm64", "osx-x64", "osx-arm64")
           foreach ($rid in $requiredRids) {
             if (-not (Test-Path "./minuit2.net/runtimes/$rid")) {
-              Write-Error "Cannot package: Missing runtime binaries for RID: $rid. Ensure all architectures are built before packing."
+              Write-Error "Cannot package: Missing runtime binaries for RID: $rid"
               exit 1
             }
           }

--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -61,10 +61,37 @@ jobs:
         shell: pwsh
         run: |
           dotnet build ./minuit2.net/minuit2.net.csproj `
+            -p:FileVersion=${{ inputs.assembly-sem-file-ver }} `
             --runtime ${{ matrix.rid }} `
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }} `
             --no-self-contained
+
+      - name: Verify Native Library Version (Windows only)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $v = [version]"${{ inputs.assembly-sem-file-ver }}"
+          $expectedVersion = "{0}.{1}.{2}.{3}" -f $v.Major, $v.Minor, [Math]::Max($v.Build, 0), [Math]::Max($v.Revision, 0)
+
+          $nativeDll = Get-ChildItem -Path "./minuit2.net/runtimes/${{ matrix.rid }}/native/*.dll" | Select-Object -First 1
+          $actualVersion = $nativeDll.VersionInfo.FileVersion
+
+          Write-Host "Verifying version for $($nativeDll.Name)"
+          Write-Host "Expected version: $expectedVersion"
+          Write-Host "Actual version:   $actualVersion"
+
+          if ($actualVersion -ne $expectedVersion) {
+              Write-Error "Native library version mismatch detected!"
+              exit 1
+          }
+
+      - name: Upload Native Library
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.rid }}-native-${{ inputs.package-id }}
+          path: ./minuit2.net/runtimes/
+          if-no-files-found: error
 
       - name: Test
         if: matrix.rid != 'win-x86'
@@ -74,13 +101,6 @@ jobs:
             --runtime ${{ matrix.rid }} `
             --configuration Release `
             -p:UseOpenMP=${{ inputs.use-openmp }}
-
-      - name: Upload Native Library
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.rid }}-native-${{ inputs.package-id }}
-          path: ./minuit2.net/runtimes/
-          if-no-files-found: error
 
   build-managed:
     name: Build .NET Assembly

--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -61,11 +61,11 @@ jobs:
         shell: pwsh
         run: |
           dotnet build ./minuit2.net/minuit2.net.csproj `
-            -p:FileVersion=${{ inputs.assembly-sem-file-ver }} `
-            --runtime ${{ matrix.rid }} `
             --configuration Release `
+            --runtime ${{ matrix.rid }} `
+            --no-self-contained `
             -p:UseOpenMP=${{ inputs.use-openmp }} `
-            --no-self-contained
+            -p:FileVersion=${{ inputs.assembly-sem-file-ver }}
 
       - name: Verify Native Library Version (Windows only)
         if: runner.os == 'Windows'
@@ -98,8 +98,8 @@ jobs:
         shell: pwsh
         run: |
           dotnet test ./test/minuit2.net.UnitTests/minuit2.net.UnitTests.csproj `
-            --runtime ${{ matrix.rid }} `
             --configuration Release `
+            --runtime ${{ matrix.rid }} `
             -p:UseOpenMP=${{ inputs.use-openmp }}
 
   build-managed:
@@ -119,13 +119,13 @@ jobs:
         shell: pwsh
         run: |
           dotnet build ./minuit2.net/minuit2.net.csproj `
+            --configuration Release `
+            --no-self-contained `
+            -p:UseOpenMP=${{ inputs.use-openmp }} `
             -p:Version=${{ inputs.sem-ver }} `
             -p:FileVersion=${{ inputs.assembly-sem-file-ver }} `
             -p:AssemblyVersion=${{ inputs.assembly-sem-ver }} `
-            -p:AssemblyInformationalVersion=${{ inputs.assembly-informational-version }} `
-            --configuration Release `
-            -p:UseOpenMP=${{ inputs.use-openmp }} `
-            --no-self-contained
+            -p:AssemblyInformationalVersion=${{ inputs.assembly-informational-version }}
 
       - name: Upload ROOT License
         uses: actions/upload-artifact@v7
@@ -190,19 +190,18 @@ jobs:
       - name: Create NuGet
         shell: pwsh
         run: |
-          dotnet pack `
+          dotnet pack ./minuit2.net/minuit2.net.csproj `
+            --configuration Release `
+            --no-build `
+            --nologo `
+            --output ./bin `
+            --warnaserror `
+            -p:UseOpenMP=${{ inputs.use-openmp }} `
             -p:Version=${{ inputs.sem-ver }} `
             -p:FileVersion=${{ inputs.assembly-sem-file-ver }} `
             -p:AssemblyVersion=${{ inputs.assembly-sem-ver }} `
             -p:AssemblyInformationalVersion=${{ inputs.assembly-informational-version }} `
-            -p:PackageId=${{ inputs.package-id }} `
-            -p:UseOpenMP=${{ inputs.use-openmp }} `
-            --no-build `
-            --configuration Release `
-            --output ./bin `
-            --warnaserror `
-            --nologo `
-            ./minuit2.net/minuit2.net.csproj
+            -p:PackageId=${{ inputs.package-id }}
 
       - name: Install dotnet-validate
         run: dotnet tool install --global dotnet-validate --version 0.0.1-preview.537

--- a/.github/workflows/minuit2-net-pipeline.yml
+++ b/.github/workflows/minuit2-net-pipeline.yml
@@ -1,5 +1,8 @@
 name: Minuit2.NET CI/CD Pipeline
-run-name: ${{ github.actor }} is creating a new version of Minuit2.NET 🚀
+run-name: >
+  ${{ github.event_name }} ·
+  ${{ github.head_ref || github.ref_name }} ·
+  ${{ github.sha }}
 
 on:
   push:

--- a/minuit2.net/minuit2.net.csproj
+++ b/minuit2.net/minuit2.net.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <Product>Minuit2.NET</Product>
         <Title>.NET wrapper for Minuit2</Title>
         <Description>A .NET wrapper for the Minuit2 library from CERN's ROOT project, enhanced with practical extensions.</Description>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <Import Project="msbuild/Build.targets"/>

--- a/minuit2.net/minuit2.net.csproj
+++ b/minuit2.net/minuit2.net.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <Product>Minuit2.NET</Product>
         <Title>.NET wrapper for Minuit2</Title>
+        <AssemblyTitle>$(Title)</AssemblyTitle>
         <Description>A .NET wrapper for the Minuit2 library from CERN's ROOT project, enhanced with practical extensions.</Description>
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>

--- a/minuit2.net/msbuild/Build.targets
+++ b/minuit2.net/msbuild/Build.targets
@@ -7,6 +7,7 @@
         <AssemblySuffix Condition="'$(UseOpenMP)' == 'ON'">.openmp</AssemblySuffix>
         <AssemblyName>minuit2.net$(AssemblySuffix)</AssemblyName>
 
+        <!-- Custom RID property avoids setting RuntimeIdentifier internally, preventing accidental creation of platform-specific .NET assembly -->
         <RID>$(RuntimeIdentifier)</RID>
         <RID Condition="'$(RID)' == ''">$(NETCoreSdkRuntimeIdentifier)</RID>
 

--- a/minuit2.net/msbuild/Build.targets
+++ b/minuit2.net/msbuild/Build.targets
@@ -7,11 +7,12 @@
         <AssemblySuffix Condition="'$(UseOpenMP)' == 'ON'">.openmp</AssemblySuffix>
         <AssemblyName>minuit2.net$(AssemblySuffix)</AssemblyName>
 
-        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+        <RID>$(RuntimeIdentifier)</RID>
+        <RID Condition="'$(RID)' == ''">$(NETCoreSdkRuntimeIdentifier)</RID>
 
         <NativeCodeDir>$(RepoDir)minuit2.wrap/</NativeCodeDir>
         <RootCloneDir>$(NativeCodeDir)root/</RootCloneDir>
-        <CmakeBuildDir>$(NativeCodeDir)build/$(RuntimeIdentifier)/</CmakeBuildDir>
+        <CmakeBuildDir>$(NativeCodeDir)build/$(RID)/</CmakeBuildDir>
         <CmakeBinaryOutputBaseDir>$(CmakeBuildDir)native/</CmakeBinaryOutputBaseDir>
     </PropertyGroup>
 

--- a/minuit2.net/msbuild/MacOS.AppleClang.targets
+++ b/minuit2.net/msbuild/MacOS.AppleClang.targets
@@ -2,8 +2,8 @@
     <PropertyGroup>
         <NativeAssemblyExtension>.dylib</NativeAssemblyExtension>
 
-        <CmakeArchitecture Condition="'$(RuntimeIdentifier)' == 'osx-x64'">x86_64</CmakeArchitecture>
-        <CmakeArchitecture Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">arm64</CmakeArchitecture>
+        <CmakeArchitecture Condition="'$(RID)' == 'osx-x64'">x86_64</CmakeArchitecture>
+        <CmakeArchitecture Condition="'$(RID)' == 'osx-arm64'">arm64</CmakeArchitecture>
 
         <!-- macOS 14 is set as the oldest target version since it is the oldest version supported by .NET8: https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md -->
         <CmakeToolchainFlags>-DCMAKE_OSX_ARCHITECTURES=$(CmakeArchitecture) -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_BUILD_TYPE=Release</CmakeToolchainFlags>
@@ -28,7 +28,7 @@
     <Target Name="ValidateCmakeToolchainFlags"
             BeforeTargets="ConfigureCmake">
         <Error Condition="'$(CmakeArchitecture)' == ''"
-               Text="The current RID '$(RuntimeIdentifier)' is not supported by the '$(Toolchain)' toolchain."/>
+               Text="The current RID '$(RID)' is not supported by the '$(Toolchain)' toolchain."/>
         <Error Condition="'$(UseOpenMP)' == 'ON' and '$(OpenMPRoot)' == ''"
                Text="The $(Toolchain) toolchain requires manual installation of the OpenMP runtime (libomp). No valid libomp path was found in standard locations. You can specify the path manually using the 'OpenMPRoot' property."/>
     </Target>

--- a/minuit2.net/msbuild/NativeBuild.targets
+++ b/minuit2.net/msbuild/NativeBuild.targets
@@ -13,7 +13,32 @@
         <MakeDir Directories="$(CmakeBuildDir);$(SwigOutputDir)"/>
     </Target>
 
-    <Target Name="TrackNativeBuildInputs">
+    <Target Name="GenerateVersionHeader">
+        <PropertyGroup>
+            <NativeFileVersion>$([MSBuild]::ValueOrDefault('$(FileVersion)', '1.0.0.0'))</NativeFileVersion>
+            <Major>$([System.Version]::Parse($(NativeFileVersion)).Major)</Major>
+            <Minor>$([System.Version]::Parse($(NativeFileVersion)).Minor)</Minor>
+            <Patch>$([System.Math]::Max($([System.Version]::Parse($(NativeFileVersion)).Build), 0))</Patch>
+            <Build>$([System.Math]::Max($([System.Version]::Parse($(NativeFileVersion)).Revision), 0))</Build>
+            <VersionHeaderContent>
+#define VERSION_MAJOR $(Major)
+#define VERSION_MINOR $(Minor)
+#define VERSION_PATCH $(Patch)
+#define VERSION_BUILD $(Build)
+#define VERSION_STRING "$(NativeFileVersion)"
+#define ORIGINAL_FILENAME "$(NativeAssemblyName)$(NativeAssemblyExtension)"
+#define PRODUCT_NAME "$(Product)"
+            </VersionHeaderContent>
+        </PropertyGroup>
+
+        <WriteLinesToFile File="$(NativeCodeDir)version.h"
+                          Lines="$(VersionHeaderContent)"
+                          Overwrite="true"
+                          WriteOnlyWhenDifferent="true"/>
+    </Target>
+
+    <Target Name="TrackNativeBuildInputs"
+            DependsOnTargets="GenerateVersionHeader">
         <ItemGroup>
             <NativeBuildSources Include="$(RepoDir)CMakeLists.txt"/>
             <NativeBuildSources Include="$(NativeCodeDir)*.*"/>

--- a/minuit2.net/msbuild/NativeBuild.targets
+++ b/minuit2.net/msbuild/NativeBuild.targets
@@ -22,7 +22,7 @@
             <NativeBuildProperties Include="$(UseOpenMP)"/>
             <NativeBuildProperties Include="$(Toolchain)"/>
             <NativeBuildProperties Include="$(SwigExePath)"/>
-            <NativeBuildProperties Include="$(RuntimeIdentifier)"/>
+            <NativeBuildProperties Include="$(RID)"/>
         </ItemGroup>
         <WriteLinesToFile File="$(IntermediateOutputPath)NativeBuildProperties"
                           Lines="@(NativeBuildProperties)"
@@ -87,7 +87,7 @@
 
         <!-- NuGet: Copy binaries to runtimes folder -->
         <Copy SourceFiles="@(NativeBinaries)"
-              DestinationFolder="runtimes/$(RuntimeIdentifier)/native/"
+              DestinationFolder="runtimes/$(RID)/native/"
               SkipUnchangedFiles="true"/>
 
         <!-- NuGet: Copy ROOT license -->

--- a/minuit2.net/msbuild/Windows.NinjaLLVM-MinGW.targets
+++ b/minuit2.net/msbuild/Windows.NinjaLLVM-MinGW.targets
@@ -2,9 +2,9 @@
     <PropertyGroup>
         <NativeAssemblyExtension>.dll</NativeAssemblyExtension>
 
-        <ClangTarget Condition="'$(RuntimeIdentifier)' == 'win-x64'">x86_64-w64-mingw32</ClangTarget>
-        <ClangTarget Condition="'$(RuntimeIdentifier)' == 'win-x86'">i686-w64-mingw32</ClangTarget>
-        <ClangTarget Condition="'$(RuntimeIdentifier)' == 'win-arm64'">aarch64-w64-mingw32</ClangTarget>
+        <ClangTarget Condition="'$(RID)' == 'win-x64'">x86_64-w64-mingw32</ClangTarget>
+        <ClangTarget Condition="'$(RID)' == 'win-x86'">i686-w64-mingw32</ClangTarget>
+        <ClangTarget Condition="'$(RID)' == 'win-arm64'">aarch64-w64-mingw32</ClangTarget>
 
         <CCompilerFlags>-DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="--target=$(ClangTarget)"</CCompilerFlags>
         <CXXCompilerFlags>-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="--target=$(ClangTarget)"</CXXCompilerFlags>
@@ -16,6 +16,6 @@
     <Target Name="ValidateCmakeToolchainFlags"
             BeforeTargets="ConfigureCmake">
         <Error Condition="'$(ClangTarget)' == ''"
-               Text="The current RID '$(RuntimeIdentifier)' is not supported by the '$(Toolchain)' toolchain."/>
+               Text="The current RID '$(RID)' is not supported by the '$(Toolchain)' toolchain."/>
     </Target>
 </Project>

--- a/minuit2.net/msbuild/Windows.VisualStudio.targets
+++ b/minuit2.net/msbuild/Windows.VisualStudio.targets
@@ -2,9 +2,9 @@
     <PropertyGroup>
         <NativeAssemblyExtension>.dll</NativeAssemblyExtension>
 
-        <CmakeArchitecture Condition="'$(RuntimeIdentifier)' == 'win-x64'">x64</CmakeArchitecture>
-        <CmakeArchitecture Condition="'$(RuntimeIdentifier)' == 'win-x86'">Win32</CmakeArchitecture>
-        <CmakeArchitecture Condition="'$(RuntimeIdentifier)' == 'win-arm64'">ARM64</CmakeArchitecture>
+        <CmakeArchitecture Condition="'$(RID)' == 'win-x64'">x64</CmakeArchitecture>
+        <CmakeArchitecture Condition="'$(RID)' == 'win-x86'">Win32</CmakeArchitecture>
+        <CmakeArchitecture Condition="'$(RID)' == 'win-arm64'">ARM64</CmakeArchitecture>
 
         <CmakeToolchainFlags>-A $(CmakeArchitecture)</CmakeToolchainFlags>
         <CmakeBinaryOutputDir>$(CmakeBinaryOutputBaseDir)Release/</CmakeBinaryOutputDir>
@@ -13,6 +13,6 @@
     <Target Name="ValidateCmakeToolchainFlags"
             BeforeTargets="ConfigureCmake">
         <Error Condition="'$(CmakeArchitecture)' == ''"
-               Text="The current RID '$(RuntimeIdentifier)' is not supported by the '$(Toolchain)' toolchain."/>
+               Text="The current RID '$(RID)' is not supported by the '$(Toolchain)' toolchain."/>
     </Target>
 </Project>

--- a/minuit2.wrap/CMakeLists.txt
+++ b/minuit2.wrap/CMakeLists.txt
@@ -10,10 +10,17 @@ SET_SOURCE_FILES_PROPERTIES(Minuit2.i PROPERTIES CPLUSPLUS ON)
 cmake_path(ABSOLUTE_PATH swig_output_dir NORMALIZE)
 cmake_path(ABSOLUTE_PATH CMAKE_CURRENT_SOURCE_DIR NORMALIZE)
 
+set(sources Minuit2.i)
+
+if(WIN32)
+    list(APPEND sources version.rc)
+    set_source_files_properties(version.rc PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/version.h")
+endif()
+
 SWIG_ADD_LIBRARY(${native_assembly_name}
   LANGUAGE csharp
   OUTPUT_DIR ${swig_output_dir}
-  SOURCES Minuit2.i)
+  SOURCES ${sources})
 
 target_include_directories(${native_assembly_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(${native_assembly_name} PROPERTIES

--- a/minuit2.wrap/version.h
+++ b/minuit2.wrap/version.h
@@ -1,0 +1,7 @@
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 0
+#define VERSION_PATCH 0
+#define VERSION_BUILD 0
+#define VERSION_STRING "1.0.0.0"
+#define ORIGINAL_FILENAME "minuit2.native.dll"
+#define PRODUCT_NAME "Minuit2.NET"

--- a/minuit2.wrap/version.rc
+++ b/minuit2.wrap/version.rc
@@ -1,0 +1,28 @@
+﻿#include <windows.h>
+#include "version.h"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+PRODUCTVERSION  VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0x0L
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "000004b0"
+        BEGIN
+            VALUE "FileDescription",  "Native Minuit2 library used by Minuit2.NET"
+            VALUE "FileVersion",      VERSION_STRING
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName",      PRODUCT_NAME
+            VALUE "ProductVersion",   VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0000, 1200
+    END
+END


### PR DESCRIPTION
Otherwise the native dll is specific to the runtime of the system it is build on.